### PR TITLE
feat(ui): add sticky scroll header with profile and CV download

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -153,6 +153,44 @@ body::before {
   --mouse-reveal-hover: 1;
 }
 
+.scroll-header {
+  position: fixed;
+  top: 1rem;
+  left: 0;
+  right: 0;
+  z-index: 30;
+  padding-inline: 1rem;
+  transition: opacity 0.28s ease, transform 0.28s ease;
+}
+
+.scroll-header__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  width: min(100%, 64rem);
+  margin: 0 auto;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid rgba(45, 212, 191, 0.16);
+  border-radius: 9999px;
+  background:
+    linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(15, 23, 42, 0.78));
+  box-shadow: 0 18px 45px rgba(2, 8, 23, 0.32);
+  backdrop-filter: blur(18px);
+}
+
+@media (max-width: 640px) {
+  .scroll-header {
+    top: 0.75rem;
+    padding-inline: 0.75rem;
+  }
+
+  .scroll-header__inner {
+    gap: 0.75rem;
+    padding: 0.65rem 0.75rem;
+  }
+}
+
 @keyframes rotate-gradient {
   0% { --gradient-angle: 0deg; }
   100% { --gradient-angle: 360deg; }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,17 +1,25 @@
 import Image from "next/image";
 import Link from "next/link";
+import { ScrollHeader } from "@/components/scroll-header";
 import { ExperienceItem } from "@/components/experience-item";
 import { ProjectItem } from "@/components/project-item";
 import { SkillItem } from "@/components/skill-item";
 import { Footer } from "@/components/footer";
 import { experience, projects, skills } from "@/data/data";
 
+const cvHref =
+  "https://drive.google.com/uc?export=download&id=1DBF2cSxI0JsrKA84dvVDAh3sNDJAdOct";
+
 export default function Page() {
   return (
     <div className="relative z-10 flex flex-col min-h-screen">
+      <ScrollHeader heroId="hero-section" cvHref={cvHref} />
       <main className="max-w-4xl mx-auto px-6 py-15 md:py-16 w-full flex flex-col gap-1">
         {/* Hero Section */}
-        <section className="flex flex-col items-center text-center pt-8 md:pt-0 mb-20 animate-fade-in-y gap-3">
+        <section
+          id="hero-section"
+          className="flex flex-col items-center text-center pt-8 md:pt-0 mb-20 animate-fade-in-y gap-3"
+        >
           <div
             className="relative w-36 h-36 md:w-48 md:h-48 mb-8 group"
             data-mouse-reveal
@@ -84,7 +92,7 @@ export default function Page() {
 
           <Link
             className="mouse-reveal-btn inline-flex items-center px-6 py-3 text-white font-medium rounded-full shadow-lg shadow-primary/20 transition-all duration-200 hover:-translate-y-0.5 animate-fade-in-y stagger-4"
-            href="https://drive.google.com/uc?export=download&id=1DBF2cSxI0JsrKA84dvVDAh3sNDJAdOct"
+            href={cvHref}
             data-mouse-reveal
           >
             Download CV

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,6 +1,6 @@
 export const Footer = () => {
   return (
-    <footer className="text-center mx-3 py-8 text-sm text-slate-500 border-t border-slate-800/50">
+    <footer className="text-center mx-3 py-8 text-sm text-slate-400 border-t border-slate-800/50">
       <p>
         © {new Date().getFullYear()} Henry Glez. Built with passion &amp;
         accessibility in mind.

--- a/components/scroll-header.tsx
+++ b/components/scroll-header.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+type ScrollHeaderProps = {
+  heroId: string;
+  cvHref: string;
+};
+
+export const ScrollHeader = ({ heroId, cvHref }: ScrollHeaderProps) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const hero = document.getElementById(heroId);
+
+    if (!hero) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsVisible(!entry.isIntersecting);
+      },
+      {
+        threshold: 0.15,
+      },
+    );
+
+    observer.observe(hero);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [heroId]);
+
+  return (
+    <div
+      aria-hidden={!isVisible}
+      className={`scroll-header ${
+        isVisible
+          ? "pointer-events-auto translate-y-0 opacity-100"
+          : "pointer-events-none -translate-y-4 opacity-0"
+      }`}
+    >
+      <div className="scroll-header__inner">
+        <div className="flex items-center gap-3 min-w-0">
+          <Image
+            className="h-11 w-11 rounded-full border border-primary/60 object-cover shadow-[0_0_20px_rgba(13,148,136,0.22)]"
+            src="/images/avatar.jpg"
+            alt="Henry Glez pictured in front of a mosaic wall on a sunny day"
+            width={44}
+            height={44}
+          />
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium uppercase tracking-[0.22em] text-primary-light/80">
+              Henry Glez
+            </p>
+            {/* <p className="truncate text-base font-semibold text-white">
+              Henry Glez
+            </p> */}
+          </div>
+        </div>
+
+        <Link
+          className="mouse-reveal-btn inline-flex shrink-0 items-center rounded-full px-4 py-2 text-sm font-medium text-white shadow-lg shadow-primary/20 "
+          href={cvHref}
+          data-mouse-reveal
+        >
+          Download CV
+        </Link>
+      </div>
+    </div>
+  );
+};

--- a/components/skill-item.tsx
+++ b/components/skill-item.tsx
@@ -14,7 +14,7 @@ export const SkillItem: React.FC<SkillItemProps> = ({ name, image, alt }) => {
           quality={50}
         />
       </div>
-      <span className="text-xs font-medium text-slate-500">{name}</span>
+      <span className="text-xs font-medium text-slate-400">{name}</span>
     </div>
   );
 };


### PR DESCRIPTION
- Add ScrollHeader component that appears when hero section scrolls out of view
- Implement IntersectionObserver to toggle header visibility based on hero section
- Style header with glassmorphic background, border, and backdrop blur
- Include profile image and name in compact header layout
- Add responsive styles for mobile devices
- Extract CV download URL to constant for reuse
- Update text colors from slate-500 to slate-400 for