### PR TITLE
fix(ui): improve skill card layout and icon sizing

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -210,10 +210,16 @@ body::before {
 
 .skill-card {
   @apply flex flex-col items-center justify-start gap-3 text-center;
+  min-width: 0;
 }
 
 /* Skill icon grayscale effect from reference */
 .skill-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
   transform-origin: center;
   transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
 }


### PR DESCRIPTION
- Add min-width: 0 to skill-card to prevent flex item overflow
- Set fixed 52px dimensions for skill-icon container
- Add flexbox centering to skill-icon for consistent alignment